### PR TITLE
Changed link flags for building on x86_64 Linux (Debian wheezy)

### DIFF
--- a/pslse/afu_driver/src/Makefile
+++ b/pslse/afu_driver/src/Makefile
@@ -2,9 +2,21 @@ CC := $(CROSS_COMPILE)$(CC)
 
 OBJ_DIR=obj
 PSL_DIR=../../psl_interface
-VPI_USER_H_DIR= # Directory that contains vpi_user.h
 
+ifndef VPI_USER_H_DIR
+VPI_USER_H_DIR= # Directory that contains vpi_user.h
+endif
+
+## NOTE: If using 32-bit VPI functions, must link as 32bit below; may require downloading 32b C libs which are not
+## installed by default on some Linux distributions
+## (eg. Debian need to do sudo dpkg --add-architecture i386; sudo apt-get install libc6:i386; )
+
+ifeq ($(shell uname) $(shell arch),Linux x86_64)
+LINK_FLAGS=-shared -E -melf_i386
+else
 LINK_FLAGS=-shared -E
+endif
+
 OBJ_FLAGS=-m32 -Wall -c -DDEBUG
 VLI_FLAGS=-m32 -Wall -g -c -fPIC -I$(VPI_USER_H_DIR) -I$(PSL_DIR) -DDEBUG
 PSL_FLAGS= $(OBJ_FLAGS) -I$(PSL_DIR)


### PR DESCRIPTION
Hi Kirk, ran into a problem with build options for the AFU driver that took a minute to track down. I think the attached branch will work for any x86_64 Linux, though I'm not sure for what flavours it is actually required. My system is Debian wheezy.
