### PR TITLE
pslse: fix debug message in cxl_mmio_write64

### DIFF
--- a/pslse/libcxl.c
+++ b/pslse/libcxl.c
@@ -815,7 +815,7 @@ int cxl_mmio_write64(struct cxl_afu_h *afu, uint64_t offset, uint64_t data) {
 		return -1;
 
 #ifdef DEBUG
-	printf ("Sending MMIO read double word to AFU\n");
+	printf ("Sending MMIO write double word to AFU\n");
 #endif /* #ifdef DEBUG */
 	status.mmio.rnw = 0;
 	status.mmio.dw = 1;


### PR DESCRIPTION
A copy/paste error prints 'read' rather than 'write'