### PR TITLE
Fixed tricky bug in mmio acknowledgment path.

### DIFF
--- a/pslse/psl_interface/psl_interface.c
+++ b/pslse/psl_interface/psl_interface.c
@@ -1,12 +1,12 @@
 /*
  * Copyright 2014 International Business Machines
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -926,7 +926,6 @@ psl_get_afu_events (struct AFU_EVENT *event)
   if ((event->rbuf[0] & 0x02) != 0)
     {
       event->buffer_rdata_valid = 1;
-      event->mmio_rdata = 0;
       for (bc = 0; bc < 128; bc++)
 	{
 	  event->buffer_rdata[bc] = event->rbuf[rbc++];


### PR DESCRIPTION
Whenever an mmio_ack and a buffer read occured on the same cycle an
mmio parity error would occur and the wrong data would be returned.
This was caused by a spuriuos line setting mmio_rdata to 0.