### PR TITLE
Response Order Improvements

### DIFF
--- a/pslse/libcxl.c
+++ b/pslse/libcxl.c
@@ -46,7 +46,7 @@
 				// 1 is an illegal value as every response
 				// would be paged.
 
-#define RESP_RANDOMIZER 10	// Setting to 1 achieves fastest responses,
+#define RESP_RANDOMIZER 5	// Setting to 1 achieves fastest responses,
 				// Large values increase response delays
 				// Zero is an illegal value
 


### PR DESCRIPTION
Hi,

This patch set randomizes the order of responses and inserts multiple preliminary buffer reads/writes at random. See the commit messages in each of the commits for more details.

Logan