### PR TITLE
Fix unused return value warning when building libcxl.c

### DIFF
--- a/libcxl/libcxl.c
+++ b/libcxl/libcxl.c
@@ -1,12 +1,12 @@
 /*
  * Copyright 2014 International Business Machines
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -501,7 +501,8 @@ struct cxl_afu_h * cxl_afu_open_h(struct cxl_afu_h *afu, enum cxl_views view)
 		goto err_exit;
 	if ((dev_name = find_dev_name(sysfs_major, sysfs_minor)) == NULL)
 		goto err_exit;
-	asprintf(&dev_path, CXL_DEV_DIR"/%s", dev_name);
+	if (asprintf(&dev_path, CXL_DEV_DIR"/%s", dev_name) < 0)
+		goto err_exit;
 	if (open_afu_dev(new_afu, dev_path))
 		goto err_pass;
 	free(dev_name);


### PR DESCRIPTION
libcxl.c:504:2: warning: ignoring return value , declared with attribute warn_unused_result [-Wunused-result]

  asprintf(&dev_path, CXL_DEV_DIR"/%s", dev_name);