### PR TITLE
Cross compile

### DIFF
--- a/libcxl/Makefile
+++ b/libcxl/Makefile
@@ -8,7 +8,7 @@ all: libcxl.so libcxl.a
 libcxl.o libcxl_sysfs.o : CFLAGS += -fPIC
 
 libcxl.so: libcxl.o libcxl_sysfs.o
-	$(CC) $(CFLAGS) -shared libcxl.o libcxl_sysfs.o -o libcxl.so
+	$(CC) $(CFLAGS) -fPIC -shared libcxl.o libcxl_sysfs.o -o libcxl.so
 
 libcxl.a: libcxl.o libcxl_sysfs.o
 	ar rcs libcxl.a libcxl.o libcxl_sysfs.o

--- a/libcxl/Makefile.rules
+++ b/libcxl/Makefile.rules
@@ -2,6 +2,6 @@
 -include $(OBJS:.o=.d)
 
 %.o : %.c
-	$(CC) $(CFLAGS) -c -o $@ $<
-	$(CC) -MM $(CFLAGS) $^ > $*.d
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+	$(CC) -MM $(CPPFLAGS) $(CFLAGS) $^ > $*.d
 	sed -i -e "s#^$(@F)#$@#" $*.d

--- a/libcxl/Makefile.vars
+++ b/libcxl/Makefile.vars
@@ -5,7 +5,7 @@ AS	= $(CROSS_COMPILE)as
 LD	= $(CROSS_COMPILE)ld
 CC	= $(CROSS_COMPILE)gcc
 ifeq ($(BIT32),y)
-CFLAGS  = -g -Wall -O2 -m32 -I$(CURDIR) -static
+CFLAGS  = -g -Wall -O2 -m32 -I$(CURDIR)
 else
-CFLAGS  = -g -Wall -O2 -m64 -I$(CURDIR) -static
+CFLAGS  = -g -Wall -O2 -m64 -I$(CURDIR)
 endif

--- a/libcxl/libcxl.c
+++ b/libcxl/libcxl.c
@@ -612,13 +612,13 @@ static int
 fprint_cxl_data_storage(FILE *stream, struct cxl_event_data_storage *event)
 {
 	return fprintf(stream, "AFU Invalid memory reference: 0x%"PRIx64"\n",
-		       event->addr);
+                   (uint64_t)event->addr);
 }
 
 static int
 fprint_cxl_afu_error(FILE *stream, struct cxl_event_afu_error *event)
 {
-	return fprintf(stream, "AFU Error: 0x%"PRIx64"\n", event->error);
+	return fprintf(stream, "AFU Error: 0x%"PRIx64"\n", (uint64_t) event->error);
 }
 
 static int hexdump(FILE *stream, __u8 *addr, ssize_t size)

--- a/libcxl/libcxl.h
+++ b/libcxl/libcxl.h
@@ -1,12 +1,12 @@
 /*
  * Copyright 2014 International Business Machines
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@
 #include <misc/cxl.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #define CXL_KERNEL_API_VERSION 1
 

--- a/pslse/Makefile
+++ b/pslse/Makefile
@@ -16,11 +16,11 @@ libcxl.a: $(OBJ_DIR)/libcxl.o $(OBJ_DIR)/psl_interface.o
 
 $(OBJ_DIR)/libcxl.o: libcxl.c libcxl.h
 	if [ ! -d $(OBJ_DIR) ];then mkdir $(OBJ_DIR);fi
-	${CC} ${PSL_FLAGS} -fPIC -c libcxl.c -o $@
+	${CC} ${CPPFLAGS} ${PSL_FLAGS} -fPIC -c libcxl.c -o $@
 
 $(OBJ_DIR)/psl_interface.o: $(PSL_DIR)/psl_interface*
 	if [ ! -d $(OBJ_DIR) ];then mkdir $(OBJ_DIR);fi
-	${CC} ${PSL_FLAGS} -fPIC -c $(PSL_DIR)/psl_interface.c -o $@
+	${CC} ${CPPFLAGS} ${PSL_FLAGS} -fPIC -c $(PSL_DIR)/psl_interface.c -o $@
 
 clean:
 	/bin/rm -f ${APP} *.a $(OBJ_DIR)/*.o


### PR DESCRIPTION
Hi,

We keep running into compile issues when we move from simulation to hardware as the header files are slightly different. I don't have access to the actual hardware so these issues can be annoying for me to test and track down. Thus, I've prepared a pull request which fixes a couple issues and also makes it possible for me to build the hardware libcxl library on non-powerpc platforms.

To summarize:
1) This commit is for our build environment so we can uniformly add a -I path for misc/cxl.h.  
2) This commit fixes libcxl.h's dependancy on stdio.h
3) Fix for build warnings on other platforms
4) Modify libcxl.c so the PPC inline assembly is replaced with equivalent C on other platforms
5) Remove the -static flag as this ought to be incorrect on all platforms (it's building a shared library) but causes build errors on my platform

There are more details in the individual commit messages.

Thanks,

Logan
