### PR TITLE
Modified cxl.h search method.

### DIFF
--- a/libcxl/Makefile
+++ b/libcxl/Makefile
@@ -5,8 +5,14 @@ OBJS = libcxl.o libcxl_sysfs.o
 
 all: cxl.h libcxl.so libcxl.a
 
-cxl.h:
-	$(error 'Please symlink include/uapi/misc/cxl.h from the Linux kernel tree')
+CHECK_HEADER = $(shell echo -e \\\#include $(1) | \
+                 $(CC) $(CPPFLAGS) -E - 2>&1 > /dev/null || echo fail)
+
+ifeq ($(call CHECK_HEADER,"<misc/cxl.h>"),)
+  PSL_FLAGS += -DHAVE_MISC_CXL_H
+else ifneq ($(call CHECK_HEADER,'"cxl.h"'),)
+  $(error 'Please symlink include/uapi/misc/cxl.h from the Linux kernel tree')
+endif
 
 libcxl.o libcxl_sysfs.o : CFLAGS += -fPIC
 

--- a/libcxl/libcxl.h
+++ b/libcxl/libcxl.h
@@ -18,7 +18,12 @@
 #define _LIBCXL_H
 
 #include <stdint.h>
+
+#ifdef HAVE_MISC_CXL_H
+#include <misc/cxl.h>
+#else
 #include "cxl.h"
+#endif
 
 #define CXL_KERNEL_API_VERSION 1
 

--- a/pslse/Makefile
+++ b/pslse/Makefile
@@ -9,10 +9,16 @@ LIBCFLAGS += -O2 -Wall -m64
 #LIBCFLAGS += -g -Wall -m64 -DDEBUG
 PSL_FLAGS= $(LIBCFLAGS) -I$(PSL_DIR)
 
-all: cxl.h libcxl.a
+CHECK_HEADER = $(shell echo -e \\\#include $(1) | \
+	         $(CC) $(CPPFLAGS) -E - 2>&1 > /dev/null || echo fail)
 
-cxl.h:
-	$(error 'Please symlink include/uapi/misc/cxl.h from the Linux kernel tree')
+ifeq ($(call CHECK_HEADER,"<misc/cxl.h>"),)
+  PSL_FLAGS += -DHAVE_MISC_CXL_H
+else ifneq ($(call CHECK_HEADER,'"cxl.h"'),)
+  $(error 'Please symlink include/uapi/misc/cxl.h from the Linux kernel tree')
+endif
+
+all: libcxl.a
 
 libcxl.a: $(OBJ_DIR)/libcxl.o $(OBJ_DIR)/psl_interface.o
 	ar rcs $@ $^

--- a/pslse/libcxl.h
+++ b/pslse/libcxl.h
@@ -1,12 +1,12 @@
 /*
  * Copyright 2014,2015 International Business Machines
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef HAVE_MISC_CXL_H
+#include <misc/cxl.h>
+#else
 #include "cxl.h"
+#endif
 
 #define CXL_KERNEL_API_VERSION 1
 


### PR DESCRIPTION
See commit message.  This also makes your develop branch slightly more backwards compatible with the master branch.

If you don't like the HAVE_MISC_CXL_H feature, I'd still recommend a change to use the CHECK_HEADER call -- this way you don't force users to symlink the cxl.h file to two locations (libcxl and pslse), they can just add an include path to CPPFLAGS or do the same with the C_INCLUDE_PATH environment variable. 

Any thought's on this?